### PR TITLE
Adding tasks and config values to enable Debian updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,12 @@ base_debian_packages:
   - 'ntp'
   - 'scsitools'
 
+# apt-get upgrade
+base_debian_upgrade: false
+
+# apt-get dist-upgrade
+base_debian_dist_upgrade: false
+
 # Define DNS servers to update to if update_dns_nameservers = true
 base_dns_nameservers:
   - '8.8.8.8'

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,6 +17,20 @@
         base_force_apt_update is defined and
         base_force_apt_update
 
+- name: debian | running apt-get dist-upgrade
+  apt:
+    upgrade: dist
+  become: true
+  when:
+    base_debian_dist_upgrade
+
+- name: debian | running apt-get upgrade
+  apt:
+    upgrade: safe
+  become: true
+  when:
+    base_debian_upgrade
+
 - name: debian | installing base packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
These updates add tasks and config values to enable Debian updates.

defaults/main.yml - added boolean base_debian_upgrade and boolean base_debian_dist_upgrade to control Debian update behavior

tasks/debian.yml - added tasks to perform updates if configured